### PR TITLE
Fix parsing for certain chords

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ var SYMBOLS = {
 
 module.exports = function(symbol) {
   var c, parsing = 'quality', additionals = [], name, chordLength = 2
-  var notes = ['P1', 'M3', 'P5', 'm7', 'M9', 'P11', 'M13'];
+  var notes = ['P1', 'M3', 'P5', 'M7', 'M9', 'P11', 'M13'];
   var explicitMajor = false;
 
   function setChord(name) {

--- a/index.js
+++ b/index.js
@@ -150,6 +150,10 @@ module.exports = function(symbol) {
             additionals.push('P11');
           else if (next === '13')
             additionals.push('M13');
+          else if (next === '4')
+            additionals.push('P4');
+          else if (next === '2')
+            additionals.push('M2');
           else {
             throw ParseError({
               title: 'Invalid token',

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ var SYMBOLS = {
 
 module.exports = function(symbol) {
   var c, parsing = 'quality', additionals = [], name, chordLength = 2
-  var notes = ['P1', 'M3', 'P5', 'M7', 'M9', 'P11', 'M13'];
+  var notes = ['P1', 'M3', 'P5', 'm7', 'M9', 'P11', 'M13'];
   var explicitMajor = false;
 
   function setChord(name) {

--- a/index.js
+++ b/index.js
@@ -58,8 +58,9 @@ module.exports = function(symbol) {
       var sub2 = (i + 1) < len ? symbol.substr(i, 2).toLowerCase() : null;
       if (sub3 in SYMBOLS)
         name = sub3;
-      else if (sub2 in SYMBOLS)
-        name = sub2;
+      else if (sub2 in SYMBOLS && symbol.substr(i + 1, 3).toLowerCase() !== "add")
+        {name = sub2;
+        console.log(sub2);}
       else if (c in SYMBOLS)
         name = c;
       else
@@ -70,7 +71,6 @@ module.exports = function(symbol) {
 
       if (name === 'M' || name === 'ma' || name === 'maj')
         explicitMajor = true;
-
 
       i += name.length - 1;
       parsing = 'extension';

--- a/index.js
+++ b/index.js
@@ -59,8 +59,7 @@ module.exports = function(symbol) {
       if (sub3 in SYMBOLS)
         name = sub3;
       else if (sub2 in SYMBOLS && symbol.substr(i + 1, 3).toLowerCase() !== "add")
-        {name = sub2;
-        console.log(sub2);}
+        name = sub2;
       else if (c in SYMBOLS)
         name = c;
       else

--- a/test/chords.js
+++ b/test/chords.js
@@ -20,7 +20,7 @@ test('Parsing chops', function(t) {
   t.deepEqual(daccord('M'), ['P1', 'M3', 'P5']);
   t.deepEqual(daccord('Ma'), ['P1', 'M3', 'P5']);
   t.deepEqual(daccord('Madd11'), ['P1', 'M3', 'P5', 'P11']);
-  t.deepEqual(daccord('madd11'), ['P1', 'm3', 'P5', 'P11'])
+  t.deepEqual(daccord('madd11'), ['P1', 'm3', 'P5', 'P11']);
   t.deepEqual(daccord('M#5'), ['P1', 'M3', 'A5']);
   t.deepEqual(daccord('maj7'), ['P1', 'M3', 'P5', 'M7']);
   t.deepEqual(daccord('+'), ['P1', 'M3', 'A5']);

--- a/test/chords.js
+++ b/test/chords.js
@@ -19,6 +19,8 @@ test('Parsing chops', function(t) {
   t.deepEqual(daccord('mi7'), ['P1', 'm3', 'P5', 'm7']);
   t.deepEqual(daccord('M'), ['P1', 'M3', 'P5']);
   t.deepEqual(daccord('Ma'), ['P1', 'M3', 'P5']);
+  t.deepEqual(daccord('Madd11'), ['P1', 'M3', 'P5', 'P11']);
+  t.deepEqual(daccord('madd11'), ['P1', 'm3', 'P5', 'P11'])
   t.deepEqual(daccord('M#5'), ['P1', 'M3', 'A5']);
   t.deepEqual(daccord('maj7'), ['P1', 'M3', 'P5', 'M7']);
   t.deepEqual(daccord('+'), ['P1', 'M3', 'A5']);


### PR DESCRIPTION
Should solve most of #1. It still fails for maj13/9, m6/9, and 13/9 chords. I'm not quite sure what a 13/9 chord should be.

I'm going to continue working on a couple things, however, on my `fixes` branch:
- Some chord parsing errors from saebekassebil/teoria#132
- Fix 6/9 chord parsing
	- Doesn't work for any 6/9 chord prefixed with a chord type (eg. Maj6/9, m6/9).
- Default to a Major 7th instead of minor 7th for chord parsing.